### PR TITLE
Fix #10: allow deep user-specified options to override those in the config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The second argument to the `RcLoader` constructor should be the options that plu
 
 **If the user specifies a string**, it is used as a path to the only config file that they care about. Calling `rcLoader.for(path)` will always return a copy of the config file at that path.
 
-**If the user specifies an object**, the following keys will be stripped from it, and the remaining values will override values found in the config file:
+**If the user specifies an object**, the following keys will be stripped from it:
 
 - `lookup`, Boolean: Find the closest config file each time `.for()` is called. default is true, unless `options` is a path.
 - `defaultFile`, string: Specify a default configuration file.
+
+If `defaultFile` is not specified, any values not not equal to `lookup` will override values found in the config file.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For build system plugins that need to fetch relative config files (like .jshintr
   - Lookups are cached to limit IO operations
   - Accepts input directly from plugin consumers to
     - specifiy a file that should always be used
+    - specify a default file
     - specify overrides
     - disable file lookup
 
@@ -46,10 +47,11 @@ var fileOpts = rcLoader.for(file.path, options);
 ```
 
 ## Options
-The second argument to the `RcLoader` constructor should be the options that plugin consumers define, and they can take can take a few different forms.
+The second argument to the `RcLoader` constructor should be the options that plugin consumers define, and it can take a few different forms.
 
 **If the user specifies a string**, it is used as a path to the only config file that they care about. Calling `rcLoader.for(path)` will always return a copy of the config file at that path.
 
-**If the user specifies an object**, the following keys will be striped from it and the remaining values will override values found in the config files.
+**If the user specifies an object**, the following keys will be stripped from it, and the remaining values will override values found in the config file:
 
- - `lookup`, Boolean, Find the closest config file each time `.for()` is called. default is true, unless config is a path.
+- `lookup`, Boolean: Find the closest config file each time `.for()` is called. default is true, unless `options` is a path.
+- `defaultFile`, string: Specify a default configuration file.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install rcloader
 ```
 
 ## Use
-This plugin was written to specifcally address this issue for a couple gulp plugins.
+This plugin was written to specifically address this issue for a couple of gulp plugins.
 
 ### within a gulp plugin
 ```js

--- a/index.js
+++ b/index.js
@@ -63,13 +63,12 @@ function RcLoader(name, userConfig, finderConfig) {
           respond(err, configFile);
         });
       }
-    if (defaultFileGiven) {
-      // treat config as the default configuration
-      configFile = _.merge(config, configFile || {});
-    } else {
-      // treat configFile as the default configuration
-      configFile = _.merge(configFile || {}, config);
-    }
+      configFile = configFile || {};
+      if (defaultFileGiven) {
+        configFile = _.merge(config, configFile);
+      } else {
+        configFile = _.merge(configFile, config);
+      }
       if (sync) return configFile;
       cb(void 0, configFile);
     }

--- a/index.js
+++ b/index.js
@@ -64,12 +64,10 @@ function RcLoader(name, userConfig, finderConfig) {
         });
       }
       var mergeCustomizer = function(objVal, srcVal, key, obj, src) {
-        if (_.has(obj, key)) {
-          if (!hasDefaultFile) {
-            // allow user-specified configurations at each level
-            // to take precedence over those in the config file
-            return obj[key];
-          }
+        if (_.has(obj, key) && !hasDefaultFile) {
+          // allow user-specified configurations at each level
+          // to take precedence over those in the config file
+          return obj[key];
         }
       };
       configFile = _.merge(config, configFile || {}, mergeCustomizer);

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function RcLoader(name, userConfig, finderConfig) {
     _.assign(config, userConfig || {});
   }
   
-  var hasDefaultFile = (config.defaultFile !== undefined); 
-  if (hasDefaultFile) {
+  var defaultFileGiven = (config.defaultFile !== undefined); 
+  if (defaultFileGiven) {
     if (finder.canLoadSync) {
       _.assign(config, finder.get(config.defaultFile));
     } else {
@@ -63,15 +63,13 @@ function RcLoader(name, userConfig, finderConfig) {
           respond(err, configFile);
         });
       }
-      var mergeCustomizer = function(objVal, srcVal, key, obj, src) {
-        if (_.has(obj, key) && !hasDefaultFile) {
-          // allow user-specified configurations at each level
-          // to take precedence over those in the config file
-          return obj[key];
-        }
-      };
-      configFile = _.merge(config, configFile || {}, mergeCustomizer);
-
+    if (defaultFileGiven) {
+      // treat config as the default configuration
+      configFile = _.merge(config, configFile || {});
+    } else {
+      // treat configFile as the default configuration
+      configFile = _.merge(configFile || {}, config);
+    }
       if (sync) return configFile;
       cb(void 0, configFile);
     }

--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ function RcLoader(name, userConfig, finderConfig) {
   } else {
     _.assign(config, userConfig || {});
   }
-
-  if (config.defaultFile) {
+  
+  var hasDefaultFile = (config.defaultFile !== undefined); 
+  if (hasDefaultFile) {
     if (finder.canLoadSync) {
       _.assign(config, finder.get(config.defaultFile));
     } else {
@@ -63,10 +64,12 @@ function RcLoader(name, userConfig, finderConfig) {
         });
       }
       var mergeCustomizer = function(objVal, srcVal, key, obj, src) {
-        if (_.has(obj, key) && obj !== config) {
-          // allow user-specified configurations to take
-          // precedence over those in the config file
-          return obj[key];
+        if (_.has(obj, key)) {
+          if (!hasDefaultFile) {
+            // allow user-specified configurations at each level
+            // to take precedence over those in the config file
+            return obj[key];
+          }
         }
       };
       configFile = _.merge(config, configFile || {}, mergeCustomizer);

--- a/index.js
+++ b/index.js
@@ -62,7 +62,14 @@ function RcLoader(name, userConfig, finderConfig) {
           respond(err, configFile);
         });
       }
-      configFile = _.merge(config, configFile || {});
+      var mergeCustomizer = function(objVal, srcVal, key, obj, src) {
+        if (_.has(obj, key) && obj !== config) {
+          // allow user-specified configurations to take
+          // precedence over those in the config file
+          return obj[key];
+        }
+      };
+      configFile = _.merge(config, configFile || {}, mergeCustomizer);
 
       if (sync) return configFile;
       cb(void 0, configFile);

--- a/test/fixtures/foo/bar.json
+++ b/test/fixtures/foo/bar.json
@@ -1,4 +1,7 @@
 {
   "baz":"bog",
-  "strict": true
+  "strict": true,
+  "globals": {
+    "describe": false
+  }
 }

--- a/test/fixtures/foo/foo/.baz
+++ b/test/fixtures/foo/foo/.baz
@@ -1,3 +1,9 @@
 {
-  "baz": "poop"
+  "baz": "poop",
+  "qux": {
+    "fart": false,
+    "smell": {
+      "good": true
+    }
+  }
 }

--- a/test/loader.js
+++ b/test/loader.js
@@ -37,7 +37,35 @@ describe('RcLoader', function () {
     var loader = new RcLoader('.baz', { from: 'defaults' });
     loader.for(fixtures.root).should.eql({
       baz: 'poop',
-      from: 'defaults'
+      from: 'defaults',
+      qux: {
+        fart: false,
+        smell: {
+          good: true
+        }
+      }
+    });
+  });
+  
+  it('recursively merges in specified default values', function () {
+    var loader = new RcLoader('.baz', { 
+      from: 'defaults', 
+      qux: {
+        fart: true, 
+        smell: {
+          good: false
+        }
+      }
+    });
+    loader.for(fixtures.root).should.eql({
+      baz: 'poop',
+      from: 'defaults',
+      qux: {
+        fart: true,
+        smell: {
+          good: false
+        }
+      }
     });
   });
 

--- a/test/loader.js
+++ b/test/loader.js
@@ -30,7 +30,7 @@ describe('RcLoader', function () {
     count.should.eql(1);
   });
 
-  it('merges in root-level specified values not in the config file', function () {
+  it('merges in root-level inline configuration values', function () {
     var loader = new RcLoader('.baz', { from: 'defaults' });
     loader.for(fixtures.root).should.eql({
       baz: 'poop',
@@ -44,7 +44,7 @@ describe('RcLoader', function () {
     });
   });
   
-  it('merges in specified values not in the config file recursively', function () {
+  it('merges in all levels of inline configuration values', function () {
     var loader = new RcLoader('.baz', {
       baz: 'bar', 
       from: 'defaults', 
@@ -152,7 +152,7 @@ describe('RcLoader', function () {
       // but config should still include the non-overriden property
       config.baz.should.equal(fixtures.barJson.baz);
 
-      // and config should have strict overriden
+      // and config should have strict overridden
       config.strict.should.equal(fixtures.jshintrc.strict);
 
       done();

--- a/test/loader.js
+++ b/test/loader.js
@@ -33,7 +33,7 @@ describe('RcLoader', function () {
     count.should.eql(1);
   });
 
-  it('merges in specified default values', function () {
+  it('merges in root-level specified values not in the config file', function () {
     var loader = new RcLoader('.baz', { from: 'defaults' });
     loader.for(fixtures.root).should.eql({
       baz: 'poop',
@@ -47,7 +47,7 @@ describe('RcLoader', function () {
     });
   });
   
-  it('recursively merges in specified default values', function () {
+  it('merges in specified values not in the config file recursively', function () {
     var loader = new RcLoader('.baz', {
       baz: 'bar', 
       from: 'defaults', 

--- a/test/loader.js
+++ b/test/loader.js
@@ -48,7 +48,8 @@ describe('RcLoader', function () {
   });
   
   it('recursively merges in specified default values', function () {
-    var loader = new RcLoader('.baz', { 
+    var loader = new RcLoader('.baz', {
+      baz: 'bar', 
       from: 'defaults', 
       qux: {
         fart: true, 
@@ -58,7 +59,7 @@ describe('RcLoader', function () {
       }
     });
     loader.for(fixtures.root).should.eql({
-      baz: 'poop',
+      baz: 'bar',
       from: 'defaults',
       qux: {
         fart: true,
@@ -94,7 +95,7 @@ describe('RcLoader', function () {
       opts.should.eql(_.merge({}, fixtures.jshintrc, fixtures.barJson));
       done();
     });
-    count ++;
+    count++;
   });
 
   it('waits for the config to load before responding', function (done) {

--- a/test/loader.js
+++ b/test/loader.js
@@ -30,20 +30,6 @@ describe('RcLoader', function () {
     count.should.eql(1);
   });
 
-  it('merges in root-level inline configuration values', function () {
-    var loader = new RcLoader('.baz', { from: 'defaults' });
-    loader.for(fixtures.root).should.eql({
-      baz: 'poop',
-      from: 'defaults',
-      qux: {
-        fart: false,
-        smell: {
-          good: true
-        }
-      }
-    });
-  });
-  
   it('merges in all levels of inline configuration values', function () {
     var loader = new RcLoader('.baz', {
       baz: 'bar', 

--- a/test/loader.js
+++ b/test/loader.js
@@ -8,11 +8,8 @@ var fixtures = {
   json: __dirname + '/fixtures/foo/bar.json',
   text: __dirname + '/fixtures/foo/foo/.baz',
   rc: __dirname + '/.jshintrc',
-  barJson: {
-    baz: 'bog',
-    strict: true
-  }
 };
+fixtures.barJson = JSON.parse(fs.readFileSync(fixtures.json));
 fixtures.jshintrc = JSON.parse(fs.readFileSync(fixtures.rc));
 
 describe('RcLoader', function () {


### PR DESCRIPTION
Fix for #10, and likely panuhorsmalahti/gulp-tslint#49. Let me know if there's anything you'd like me to change. Also documents `defaultFile` option, #12.

    rcloader (master *% u= ?!) $ node_modules/.bin/mocha

      RcLoader
        ✓ loads a config file relative to another file
        ✓ passes the constructors third arg to RcFinder
        ✓ merges in all levels of inline configuration values
        ✓ accepts a string which disables lookup and always responds with it's contents
        ✓ does not lookup files when { lookup: false }
        ✓ accepts a path at { defaultFile: "..." }
        ✓ waits for the config to load before responding


      7 passing (20ms)

:beers: 